### PR TITLE
set autoDelete:true for queues so unused queues are deleted

### DIFF
--- a/lib/qwen.js
+++ b/lib/qwen.js
@@ -43,7 +43,7 @@ Qwen.prototype.subscribe = function (params, handler) {
   function subscriber(done) {
     qwen.channel.assertExchange(exchange, 'direct', {durable: true}, (err) => {
       if (err) return done(err)
-      var q = qwen.channel.assertQueue('', {})
+      var q = qwen.channel.assertQueue('', {autoDelete : true})
       qwen.channel.bindQueue(q.queue, exchange, key)
       qwen.channel.consume(q.queue, (msg) => {
         qwen.log.info({info: 'Message received', message: logMessage(msg)})


### PR DESCRIPTION
I noticed when you restart the `alpha-services` app, the old queues are not deleted. This is a problem because very quick there will be tonnes of queues not being consumed but they'll still fill up with messages.

This option should change that.